### PR TITLE
Run `oasis setup` after sed'ing the _oasis file

### DIFF
--- a/travis-coveralls.sh
+++ b/travis-coveralls.sh
@@ -10,6 +10,7 @@ function instrument_oasis {
     sed -i '/ByteOpt:/ s/$/ -ppxopt bisect_ppx,"-exclude-file ..\/.coverage.excludes"/' _oasis
     sed -i '/NativeOpt:/ s/$/ -ppxopt bisect_ppx,"-exclude-file ..\/.coverage.excludes"/' _oasis
   fi
+  oasis setup
 }
 
 function instrument_omake {


### PR DESCRIPTION
This line was dropped accidentally in d4c27d9.
